### PR TITLE
RHMAP-20375 -  Add support for the version 8 of NodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This module makes testing of RHMAP components easier by running a build jobs wit
 `fh-build`'s main purpose is to be installed as a tool in CI testing, e.g. in [Travis CI](http://travis-ci.org).
 
 It contains a shell script installing couple of dependencies:
-- npm@2.13.5 for node v4 or npm@3.10.8 for node v6
+- npm@2.13.5 for node v4, or npm@3.10.8 for node v6 or npm@5.6.0 for node v8
 - [grunt-cli](https://www.npmjs.com/package/grunt-cli)
 - [fh-npm](https://www.npmjs.com/package/fh-npm)
 - [s2i](https://github.com/openshift/source-to-image)

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,11 @@ function template () {
   # Find out Node version => choose appropriate docker build-image
   nodeversion=`node -v`
   npmversion=""
-  if [[ $nodeversion == "v6"* ]]
+  if [[ $nodeversion == "v8"* ]]
+  then
+    buildimage="registry.access.redhat.com/rhscl/nodejs-8-rhel7"
+    npmversion="5.6.0"
+  elif [[ $nodeversion == "v6"* ]]
   then
     buildimage="registry.access.redhat.com/rhscl/nodejs-6-rhel7"
     npmversion="3.10.8"
@@ -16,27 +20,27 @@ function template () {
     buildimage="registry.access.redhat.com/openshift3/nodejs-010-rhel7"
     npmversion="2.13.5"
   fi
-  
+
   # npm installation
   eval "npm install -g npm@$npmversion"
-  
+
   # grunt installation
   npm install -g grunt-cli
-  
+
   # fh-npm dependency installation
   npm install -g fh-npm@0.0.12-66
-  
+
   # fh-npm build test
   fhnpm="`which node` `which npm`"
   fhnpm_install="install --production --strict-ssl=false --cache=$HOME/.fh-npm/fhnpm_install_cache"
   fhnpm_cache="$HOME/.fh-npm/fhnpm_cache"
   dynodir=`pwd`
   fh-npm --npm="$fhnpm" --install="$fhnpm_install" --dir="$dynodir" --cache="$fhnpm_cache"
-  
+
   # s2i dependencies installation
   sudo apt-get install golang -y
   curl -L https://github.com/openshift/source-to-image/releases/download/v1.0.9/source-to-image-v1.0.9-f9ff77d-linux-amd64.tar.gz | tar -xz
-  
+
   # s2i build test
   ./s2i build . $buildimage build_test
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-build",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A module for building RHMAP components",
   "main": "./index.js",
   "bin": {


### PR DESCRIPTION
## JIRA:

https://issues.jboss.org/browse/RHMAP-20375

## What

Add support for NodeJS 8.

## Why

The version 4 is already deprecated and the version 6 will be in 12 months, then we need start to support the version 8. 

